### PR TITLE
Add HTTP Link header for Markdown alternate

### DIFF
--- a/includes/routing.php
+++ b/includes/routing.php
@@ -344,7 +344,7 @@ add_action( 'send_headers', function (): void {
     }
 
     // Only on normal HTML responses (not when we're serving Markdown).
-    if ( mfa_should_serve_markdown() ) {
+    if ( botkibble_should_serve_markdown() ) {
         return;
     }
 
@@ -357,7 +357,7 @@ add_action( 'send_headers', function (): void {
         return;
     }
 
-    $allowed = apply_filters( 'markdown_served_post_types', [ 'post', 'page' ] );
+    $allowed = apply_filters( 'botkibble_served_post_types', [ 'post', 'page' ] );
     if ( ! in_array( $post->post_type, $allowed, true ) ) {
         return;
     }


### PR DESCRIPTION
## Summary
- Emit an HTTP `Link` response header on singular HTML responses advertising the Markdown alternate representation (`rel=\"alternate\"; type=\"text/markdown\"`).
- Complements the existing `<link rel=\"alternate\" type=\"text/markdown\">` tag for clients that only inspect headers (HEAD requests, some bots, tooling).

## Behavior
- Only runs for `is_singular()` posts in `markdown_served_post_types`.
- Does not run when serving the Markdown response (`mfa_should_serve_markdown()`).
- Appends without replacing existing `Link` headers.

## Test plan
- `curl -I <post-url>` and verify a `Link` header points to `?format=markdown` with `rel=\"alternate\"`.
- `curl -I <post-url>?format=markdown` and verify the Markdown response still includes `rel=\"canonical\"` back to the HTML URL.

Made with [Cursor](https://cursor.com)