### PR TITLE
Make advertised Markdown URL configurable (suffix vs query)

### DIFF
--- a/includes/routing.php
+++ b/includes/routing.php
@@ -321,7 +321,10 @@ add_action( 'wp_head', function (): void {
         return;
     }
 
-    $url = add_query_arg( 'format', 'markdown', get_permalink( $post ) );
+    $url = mfa_get_markdown_alternate_url( $post );
+    if ( ! $url ) {
+        return;
+    }
     printf(
         '<link rel="alternate" type="text/markdown" href="%s" />' . "\n",
         esc_url( $url )
@@ -362,7 +365,10 @@ add_action( 'send_headers', function (): void {
         return;
     }
 
-    $markdown_url = add_query_arg( 'format', 'markdown', get_permalink( $post ) );
+    $markdown_url = mfa_get_markdown_alternate_url( $post );
+    if ( ! $markdown_url ) {
+        return;
+    }
     // Append (don't replace) any existing Link headers.
     header(
         'Link: <' . esc_url_raw( $markdown_url ) . '>; rel="alternate"; type="text/markdown"',
@@ -506,6 +512,62 @@ function mfa_regen_throttled(): bool {
 /* --------------------------------------------------------------------------
  * Response helpers
  * ---------------------------------------------------------------------- */
+
+/**
+ * Get the preferred Markdown URL for a post, used for discovery links/headers.
+ *
+ * Defaults to the query-param endpoint (`?format=markdown`), but can be switched
+ * to the `.md` suffix or Accept-header representation via filters.
+ *
+ * Modes:
+ * - query  (default): https://example.com/post/?format=markdown
+ * - suffix:           https://example.com/post.md
+ * - accept:           https://example.com/post/  (representation via Accept: text/markdown)
+ *
+ * To override completely, use the `markdown_alternate_url` filter and return
+ * an absolute URL string or an empty string to disable discovery output.
+ */
+function mfa_get_markdown_alternate_url( WP_Post $post ): string {
+    $mode = (string) apply_filters( 'markdown_alternate_url_mode', 'query', $post );
+    $mode = strtolower( trim( $mode ) );
+    if ( ! in_array( $mode, [ 'query', 'suffix', 'accept' ], true ) ) {
+        $mode = 'query';
+    }
+
+    $permalink = get_permalink( $post );
+    if ( ! $permalink ) {
+        return '';
+    }
+
+    if ( 'accept' === $mode ) {
+        $url = $permalink;
+    } elseif ( 'suffix' === $mode ) {
+        // Front page + `.md` is not reliably handled by rewrite rules ('.md' won't match),
+        // so default to the query endpoint for the homepage.
+        $path = wp_parse_url( $permalink, PHP_URL_PATH ) ?: '';
+        if ( '/' === $path ) {
+            $url = add_query_arg( 'format', 'markdown', home_url( '/' ) );
+        } else {
+            $url = untrailingslashit( $permalink ) . '.md';
+        }
+    } else {
+        // query
+        $url = add_query_arg( 'format', 'markdown', $permalink );
+    }
+
+    /**
+     * Filter the final Markdown alternate URL used in discovery.
+     *
+     * Return an empty string to suppress the discovery link/header entirely.
+     *
+     * @param string  $url  The computed alternate URL.
+     * @param WP_Post $post The current post.
+     * @param string  $mode The selected mode: query|suffix|accept.
+     */
+    $url = (string) apply_filters( 'markdown_alternate_url', $url, $post, $mode );
+
+    return trim( $url );
+}
 
 /**
  * Sanitize a URI into a safe cache slug, or return '' to reject.

--- a/includes/routing.php
+++ b/includes/routing.php
@@ -517,20 +517,16 @@ function mfa_regen_throttled(): bool {
  * Get the preferred Markdown URL for a post, used for discovery links/headers.
  *
  * Defaults to the query-param endpoint (`?format=markdown`), but can be switched
- * to the `.md` suffix or Accept-header representation via filters.
+ * to the `.md` suffix via a filter.
  *
  * Modes:
  * - query  (default): https://example.com/post/?format=markdown
  * - suffix:           https://example.com/post.md
- * - accept:           https://example.com/post/  (representation via Accept: text/markdown)
- *
- * To override completely, use the `markdown_alternate_url` filter and return
- * an absolute URL string or an empty string to disable discovery output.
  */
 function mfa_get_markdown_alternate_url( WP_Post $post ): string {
     $mode = (string) apply_filters( 'markdown_alternate_url_mode', 'query', $post );
     $mode = strtolower( trim( $mode ) );
-    if ( ! in_array( $mode, [ 'query', 'suffix', 'accept' ], true ) ) {
+    if ( ! in_array( $mode, [ 'query', 'suffix' ], true ) ) {
         $mode = 'query';
     }
 
@@ -539,9 +535,7 @@ function mfa_get_markdown_alternate_url( WP_Post $post ): string {
         return '';
     }
 
-    if ( 'accept' === $mode ) {
-        $url = $permalink;
-    } elseif ( 'suffix' === $mode ) {
+    if ( 'suffix' === $mode ) {
         // Front page + `.md` is not reliably handled by rewrite rules ('.md' won't match),
         // so default to the query endpoint for the homepage.
         $path = wp_parse_url( $permalink, PHP_URL_PATH ) ?: '';
@@ -554,17 +548,6 @@ function mfa_get_markdown_alternate_url( WP_Post $post ): string {
         // query
         $url = add_query_arg( 'format', 'markdown', $permalink );
     }
-
-    /**
-     * Filter the final Markdown alternate URL used in discovery.
-     *
-     * Return an empty string to suppress the discovery link/header entirely.
-     *
-     * @param string  $url  The computed alternate URL.
-     * @param WP_Post $post The current post.
-     * @param string  $mode The selected mode: query|suffix|accept.
-     */
-    $url = (string) apply_filters( 'markdown_alternate_url', $url, $post, $mode );
 
     return trim( $url );
 }


### PR DESCRIPTION
## Summary
Adds a small filter-based configuration for which Markdown URL is advertised in discovery output:
- HTML `<head>`: `<link rel=\"alternate\" type=\"text/markdown\" …>`
- HTTP header: `Link: <…>; rel=\"alternate\"; type=\"text/markdown\"`

## New filter
- `markdown_alternate_url_mode` (default: `query`)
  - `query`: advertise `?format=markdown`
  - `suffix`: advertise `.md` (falls back to the query endpoint for the front page)

## Notes
This PR is stacked on top of PR #2. If PR #2 merges first, GitHub should show this PR as only the incremental commits.

## Test plan
- Set `add_filter('markdown_alternate_url_mode', fn() => 'suffix');` and verify headers/`<head>` advertise `post.md`.
- Set it back to `query` and verify it advertises `?format=markdown`.