### PR TITLE
Add opt-in converter remove_nodes hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The plugin is highly extensible via WordPress filters:
 | `botkibble_served_post_types` | Add custom post types (e.g., `docs`, `product`). |
 | `botkibble_frontmatter` | Add or remove fields in the YAML block. |
 | `botkibble_clean_html` | Clean up HTML (remove specific divs/styles) before conversion. |
+| `botkibble_converter_remove_nodes` | Opt in to removing full HTML node types in converter (e.g., `script`). |
 | `botkibble_output` | Modify the final Markdown string before it's cached/served. |
 | `botkibble_cache_variant` | Override the cache variant for the current request (used with `?botkibble_variant=...`). |
 | `botkibble_cache_variants` | Return a list of cache variants to invalidate on post updates (e.g., `['slim']`). |
@@ -106,6 +107,23 @@ add_filter( 'botkibble_served_post_types', function ( $types ) {
     return $types;
 } );
 ```
+
+### Example: Opt In To Script Node Removal (JSON-LD Safe)
+
+By default, Botkibble does not set converter `remove_nodes`, preserving legacy behavior.
+If you want to strip remaining scripts at conversion time, opt in with:
+
+```php
+add_filter( 'botkibble_converter_remove_nodes', function ( $nodes ) {
+    $nodes = is_array( $nodes ) ? $nodes : [];
+    $nodes[] = 'script';
+    return $nodes;
+} );
+```
+
+If your site needs JSON-LD from content HTML, extract it first with `botkibble_clean_html`
+and remove only `application/ld+json` blocks there. The converter-level `script` removal
+then acts as a final safety net for other scripts.
 
 ## Requirements
 

--- a/includes/converter.php
+++ b/includes/converter.php
@@ -303,16 +303,69 @@ function botkibble_render_body( WP_Post $post ): array {
 
     static $converter = null;
     if ( null === $converter ) {
-        $converter = new HtmlConverter( [
+        $converter_options = [
             'strip_tags' => true,
             'hard_break' => true,
-        ] );
+        ];
+
+        /**
+         * Optional: remove entire DOM node types before conversion.
+         *
+         * Keep this empty by default to preserve legacy behavior.
+         * Example return values:
+         * - array: [ 'script', 'style' ]
+         * - string: 'script style'
+         *
+         * @param array<int, string>|string $remove_nodes Requested node names.
+         * @param WP_Post                   $post         Current post being rendered.
+         */
+        $remove_nodes = apply_filters( 'botkibble_converter_remove_nodes', [], $post );
+        $remove_nodes = botkibble_normalize_remove_nodes( $remove_nodes );
+        if ( ! empty( $remove_nodes ) ) {
+            $converter_options['remove_nodes'] = implode( ' ', $remove_nodes );
+        }
+
+        $converter = new HtmlConverter( $converter_options );
     }
 
     return [
         'markdown'   => $converter->convert( $html ),
         'word_count' => $word_count,
     ];
+}
+
+/**
+ * Normalize a converter remove_nodes value into a clean list of tag names.
+ *
+ * Accepts either a string (space/comma-separated) or an array of values and
+ * returns unique lowercase tag names safe to pass to HtmlConverter.
+ *
+ * @param array<int, mixed>|string $nodes Raw filter value.
+ * @return array<int, string>
+ */
+function botkibble_normalize_remove_nodes( $nodes ): array {
+    if ( is_string( $nodes ) ) {
+        $nodes = preg_split( '/[\s,]+/', $nodes ) ?: [];
+    } elseif ( ! is_array( $nodes ) ) {
+        return [];
+    }
+
+    $out = [];
+    foreach ( $nodes as $node ) {
+        $name = strtolower( trim( (string) $node ) );
+        if ( '' === $name ) {
+            continue;
+        }
+
+        // Keep DOM-like node names only (e.g. script, style, iframe).
+        if ( ! preg_match( '/^[a-z][a-z0-9:_-]*$/', $name ) ) {
+            continue;
+        }
+
+        $out[ $name ] = true;
+    }
+
+    return array_keys( $out );
 }
 
 /* --------------------------------------------------------------------------

--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,18 @@ Yes, use the `botkibble_clean_html` filter. This runs after the default cleanup 
         return $html;
     } );
 
+= Can I strip script nodes during conversion? =
+
+Yes. Botkibble keeps converter node removal disabled by default (for backward compatibility), but you can opt in with `botkibble_converter_remove_nodes`:
+
+    add_filter( 'botkibble_converter_remove_nodes', function ( $nodes ) {
+        $nodes = is_array( $nodes ) ? $nodes : [];
+        $nodes[] = 'script';
+        return $nodes;
+    } );
+
+If you also need `application/ld+json`, extract it in `botkibble_clean_html` first, then let converter-level script removal clean up any remaining script tags.
+
 = How do I modify the final Markdown output? =
 
 Use the `botkibble_output` filter to append or modify the text after conversion:


### PR DESCRIPTION
## Summary
- Add a new `botkibble_converter_remove_nodes` filter in `includes/converter.php` to let downstream projects opt into converter-level node removal.
- Keep default Botkibble behavior unchanged by only setting HtmlConverter `remove_nodes` when the new filter returns values.
- Document hook usage in `README.md` and `readme.txt`, including an opt-in `script` removal example.

## Test plan
- [x] Run `php -l includes/converter.php`
- [x] Verify no linter diagnostics on modified files
- [x] Confirm clean working tree after commit
- [ ] On a downstream site, add `botkibble_converter_remove_nodes` with `script`.
- [ ] Verify `<script>` tags are removed from markdown output when the hook is enabled.
- [ ] Verify default behavior is unchanged when the hook is not attached.

Made with [Cursor](https://cursor.com)